### PR TITLE
Add details specific to Debian-based installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ screeps init
 screeps start
 ```
 
+If installing on Debian-based Linux distributions (such as Ubuntu) make sure to install the `build-essential` package first, as otherwise various components of screeps that require native compiling can fail in ways which are hard to troubleshoot.
+
 Prerequisites:
  * Node.js 6 or higher
  * Python 2 (for node-gyp, [Python 3 is not supported](https://github.com/nodejs/node-gyp/issues/193)) 


### PR DESCRIPTION
Debian and derivative distributions do not configure the environment for compiling native code by default, and require the `build-essential` package to be installed first. Not having this installed can cause various strange failure-to-start-server issues which log with all manner of error messages ranging from permission errors to file-not-found ones.

This small PR updates the main readme to include a note regarding this pre-req.