### PR TITLE
Add link for updated Node.js install packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npx screeps start
 ```
 
 Prerequisites:
- * Node.js 8 LTS or higher
+ * Node.js 8 LTS or higher (the Node.js core team maintains a [directory of links for installing updated Node.js versions](https://nodejs.org/en/download/package-manager/))
  * Python 2 (for node-gyp, [Python 3 is not supported](https://github.com/nodejs/node-gyp/issues/193))
  * Build tools (`apt install build-essential` for Ubuntu, [Visual Studio](https://www.visualstudio.com/vs/) for Windows, etc) 
 


### PR DESCRIPTION
Just adding a small call-out to the official directory of pre-packaged Node.js versions to streamline getting the required 8.x version installed on systems.

This would also for the most part resolve https://github.com/screeps/screeps/issues/62 as well.