### PR TITLE
LICENSE.txt: add title

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+ISC License
+
 Copyright (c) 2016, Artem Chivchalov <contact@screeps.com>
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted,


### PR DESCRIPTION
Although the title is not legally mandated for the license to apply, it is strongly recommended, and actually included in the license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license). This provides additional clarity regarding the licensing terms.

*Note: This PR is part of a personal project to improve the consistency and visibility of the ISC license. See https://github.com/github/choosealicense.com/issues/377 for more details.*