### PR TITLE
Update Node requirement to force Node.js version10

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npx screeps start
 ```
 
 Prerequisites:
- * Node.js 10 LTS or higher
+ * Node.js (version 10, >=10.13.0 but <11.0.0)
  * Python 2 (for node-gyp, [Python 3 is not supported](https://github.com/nodejs/node-gyp/issues/193))
  * Build tools (`apt install build-essential` for Ubuntu, [Visual Studio](https://www.visualstudio.com/vs/) for Windows, etc) 
 


### PR DESCRIPTION
Node versions 12 and 14 are known not to work, this will force a 10.x version >=10.13.0 <11.0.0

Closes #123 