### PR TITLE
Fixed postinstall path on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "screeps": "bin/screeps.js"
   },
   "scripts": {
-    "postinstall": "cd `node_modules` && npm explore @screeps/driver -- npx webpack"
+    "postinstall": "cd \"node_modules\" && npm explore @screeps/driver -- npx webpack"
   },
   "author": "Artem Chivchalov <contact@screeps.com>",
   "license": "ISC",


### PR DESCRIPTION
Corrected the quotation marks to work on windows, fixes issue https://github.com/screeps/screeps/issues/166.